### PR TITLE
LEIA: Avoid throwing an instance of 'std::length_error'

### DIFF
--- a/simulateur/main.cpp
+++ b/simulateur/main.cpp
@@ -98,8 +98,16 @@ int main(int argc, char* argv[]) {
     {
         using namespace std;
         string dir = argv[0];
-        dir.resize(dir.rfind('/')); // dirname of argv[0], i.e. LEIA directory.
-        loadClockTicksRc(dir, ct);
+	int pos = dir.rfind('/');
+	if (pos != -1) {
+		dir.resize(pos); // dirname of argv[0],
+		                 // i.e. LEIA directory.
+		loadClockTicksRc(dir, ct);
+	} else {
+		// We couldn't find the .rc file. Use hardcoded default.
+		ct.click_constant = 0;
+		ct.add_t = 1;
+	}
     }
     Param param;
 	bool quiet = false;


### PR DESCRIPTION
When calling just "LEIA" (!= ./LEIA), argv[0] is just "LEIA" (unlike $0
in shell), so the old code was not finding / and then raising an
exception.

There's no easy and portable way to find the path to the executable (or:
if you have one, feel free to add it to the code), so let's just use
hardcoded constants when we can't find the file.